### PR TITLE
changed column to wrap, and title to headline6

### DIFF
--- a/lib/widgets/project_widget.dart
+++ b/lib/widgets/project_widget.dart
@@ -1,20 +1,21 @@
 import 'package:adityagurjar/models/project_model.dart';
 import 'package:flutter/material.dart';
 import 'dart:html' as html;
+
 class ProjectWidget extends StatelessWidget {
   final Project _project;
   final double _bottomPadding;
-  ProjectWidget(this._project,this._bottomPadding );
+  ProjectWidget(this._project, this._bottomPadding);
 
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     final height = MediaQuery.of(context).size.height;
     return Card(
-        margin: EdgeInsets.fromLTRB(16.0,16.0,16.0,_bottomPadding),
-        child:InkWell(
-          onTap: onProjectClick,
-          child:  Padding(
+      margin: EdgeInsets.fromLTRB(16.0, 16.0, 16.0, _bottomPadding),
+      child: InkWell(
+        onTap: onProjectClick,
+        child: Padding(
           padding: const EdgeInsets.all(8.0),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -25,7 +26,7 @@ class ProjectWidget extends StatelessWidget {
                   child: Image.asset(
                     _project.image,
                     width: width * .25,
-                    height: width*.25,
+                    height: width * .25,
                   )),
               Expanded(
                 flex: 3,
@@ -35,13 +36,13 @@ class ProjectWidget extends StatelessWidget {
                 flex: 60,
                 child: Container(
                   padding: EdgeInsets.only(top: 8.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                  child: Wrap(
+                    direction: Axis.horizontal,
                     children: <Widget>[
-                      Text(_project.name,
-                          style: Theme.of(context).textTheme.title),
+                      Text(
+                        _project.name,
+                        style: Theme.of(context).textTheme.headline6,
+                      ),
                       SizedBox(
                         height: height * .01,
                       ),
@@ -61,9 +62,7 @@ class ProjectWidget extends StatelessWidget {
     );
   }
 
-  void onProjectClick(){
-      if(_project.link!=null)
-       html.window.open(_project.link, 'adityadroid'); 
-    }
-
+  void onProjectClick() {
+    if (_project.link != null) html.window.open(_project.link, 'adityadroid');
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0-nullsafety.2"
   charcode:
     dependency: transitive
     description:
@@ -21,7 +28,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0-nullsafety.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -47,7 +54,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.2"
   path:
     dependency: transitive
     description:
@@ -94,13 +101,13 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0-nullsafety.2"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.2"
 sdks:
-  dart: ">=2.2.2 <3.0.0"
+  dart: ">=2.10.0-0.0.dev <2.10.0"


### PR DESCRIPTION
i changed `Column` widget to `Wrap` inisde `project_widget` file, because the project description get overflowed on certain windows sizes using `Column`

with Column: 
![image](https://user-images.githubusercontent.com/52101936/91016150-0319eb80-e5f5-11ea-918b-5261242ba88f.png)

with Wrap:
![image](https://user-images.githubusercontent.com/52101936/91016181-0e6d1700-e5f5-11ea-8e5e-ae98af8639bf.png)

I also removed the deprecated `textTheme: title` property from project name text style and replaced it with the new one which is `headline6`.